### PR TITLE
Change DrawTarget::stroke arguments order to match DrawTarget::fill.

### DIFF
--- a/examples/capabilities.rs
+++ b/examples/capabilities.rs
@@ -110,6 +110,7 @@ fn main() {
     let path = pb.finish();
     dt.stroke(
         &path,
+        &gradient,
         &StrokeStyle {
             cap: LineCap::Butt,
             join: LineJoin::Bevel,
@@ -118,7 +119,6 @@ fn main() {
             dash_array: vec![10., 5.],
             dash_offset: 3.,
         },
-        &gradient,
     );
 
     let font = SystemSource::new()

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -257,7 +257,7 @@ impl DrawTarget {
         self.composite(src, &mask.data, rect(x, y, mask.width, mask.height));
     }
 
-    pub fn stroke(&mut self, path: &Path, style: &StrokeStyle, src: &Source) {
+    pub fn stroke(&mut self, path: &Path, src: &Source, style: &StrokeStyle) {
         let mut path = path.flatten(0.1);
         if !style.dash_array.is_empty() {
             path = dash_path(&path, &style.dash_array, style.dash_offset);


### PR DESCRIPTION
Currently, the `src` argument in the `stroke` method is the last one, but in `fill` it's last but one.

This patch makes order similar in `stroke` and `fill`: self, path, src, style/winding_mode.