### PR TITLE
Reexport Path and PathOp.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod stroke;
 mod tests;
 
 mod path_builder;
-pub use path_builder::PathBuilder;
+pub use path_builder::*;
 
 pub use crate::draw_target::{DrawTarget, SolidSource, Source, Winding};
 pub use crate::stroke::*;


### PR DESCRIPTION
This types are public, but not exported.