### PR TITLE
Allow clearing with any color

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -355,21 +355,16 @@ impl DrawTarget {
         self.rasterizer.reset();
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self, solid: SolidSource) {
         let mut pb = PathBuilder::new();
         let ctm = self.transform;
         self.transform = Transform::identity();
         pb.rect(0., 0., self.width as f32, self.height as f32);
         self.fill(
             &pb.finish(),
-            &Source::Solid(SolidSource {
-                r: 0,
-                g: 0,
-                b: 0,
-                a: 0,
-            }),
+            &Source::Solid(solid),
             &DrawOptions {
-                blend_mode: BlendMode::Clear,
+                blend_mode: BlendMode::Src,
             },
         )
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -102,7 +102,7 @@ mod tests {
             }),
             &DrawOptions::new(),
         );
-        dt.clear();
+        dt.clear(SolidSource { r: 0, g: 0, b: 0, a: 0 });
         assert_eq!(dt.get_data(), &vec![0, 0, 0, 0][..])
     }
 }


### PR DESCRIPTION
It would be nice to be able to clear with any color, as this is what Piet allows.

I am unsure if it is better to accept a `SolidSource` or just a `u32` in rgba format