### PR TITLE
Use u32 for size.

### DIFF
--- a/src/blitter.rs
+++ b/src/blitter.rs
@@ -7,8 +7,8 @@ pub trait Blitter {
 }
 
 pub struct MaskSuperBlitter {
-    width: i32,
-    height: i32,
+    width: u32,
+    height: u32,
     pub buf: Vec<u8>,
 }
 
@@ -23,7 +23,7 @@ fn coverage_to_partial_alpha(mut aa: i32) -> u8 {
 }
 
 impl MaskSuperBlitter {
-    pub fn new(width: i32, height: i32) -> MaskSuperBlitter {
+    pub fn new(width: u32, height: u32) -> MaskSuperBlitter {
         MaskSuperBlitter {
             width,
             height,
@@ -47,7 +47,7 @@ fn saturated_add(a: u8, b: u8) -> u8 {
 impl Blitter for MaskSuperBlitter {
     fn blit_span(&mut self, y: i32, x1: i32, x2: i32) {
         let max: u8 = ((1 << (8 - SHIFT)) - (((y & MASK) + 1) >> SHIFT)) as u8;
-        let mut b: *mut u8 = &mut self.buf[(y / 4 * self.width + (x1 >> SHIFT)) as usize];
+        let mut b: *mut u8 = &mut self.buf[(y / 4 * self.width as i32 + (x1 >> SHIFT)) as usize];
 
         let mut fb = x1 & SUPER_MASK;
         let fe = x2 & SUPER_MASK;

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -151,8 +151,8 @@ struct Layer {
 }
 
 pub struct DrawTarget {
-    width: i32,
-    height: i32,
+    width: u32,
+    height: u32,
     rasterizer: Rasterizer,
     current_point: Point,
     first_point: Point,
@@ -163,7 +163,7 @@ pub struct DrawTarget {
 }
 
 impl DrawTarget {
-    pub fn new(width: i32, height: i32) -> DrawTarget {
+    pub fn new(width: u32, height: u32) -> DrawTarget {
         DrawTarget {
             width,
             height,
@@ -317,7 +317,7 @@ impl DrawTarget {
     fn clip_bounds(&self) -> IntRect {
         self.clip_stack.last().map(|c| c.rect).unwrap_or(IntRect::new(
             euclid::Point2D::new(0, 0),
-            euclid::Point2D::new(self.width, self.height),
+            euclid::Point2D::new(self.width as i32, self.height as i32),
         ))
     }
 
@@ -351,7 +351,7 @@ impl DrawTarget {
         self.apply_path(path);
         let mut blitter = MaskSuperBlitter::new(self.width, self.height);
         self.rasterizer.rasterize(&mut blitter, path.winding);
-        self.composite(src, &blitter.buf, intrect(0, 0, self.width, self.height), options.blend_mode);
+        self.composite(src, &blitter.buf, intrect(0, 0, self.width as i32, self.height as i32), options.blend_mode);
         self.rasterizer.reset();
     }
 
@@ -492,7 +492,7 @@ impl DrawTarget {
 
         let (dest, dest_bounds) = match self.layer_stack.last_mut() {
             Some(layer) => (&mut layer.buf[..], layer.rect),
-            None => (&mut self.buf[..], intrect(0, 0, self.width, self.height))
+            None => (&mut self.buf[..], intrect(0, 0, self.width as i32, self.height as i32))
         };
 
         rect = rect
@@ -515,14 +515,14 @@ impl DrawTarget {
                          mask: Some(clip),
                      }) => {
                     scb = ShaderClipBlitter {
-                        shader: shader,
+                        shader,
                         tmp: vec![0; self.width as usize],
                         dest,
                         dest_stride: dest_bounds.size().width,
                         mask,
-                        mask_stride: self.width,
+                        mask_stride: self.width as i32,
                         clip,
-                        clip_stride: self.width,
+                        clip_stride: self.width as i32,
                     };
 
                     blitter = &mut scb;
@@ -534,7 +534,7 @@ impl DrawTarget {
                         dest,
                         dest_stride: dest_bounds.size().width,
                         mask,
-                        mask_stride: self.width,
+                        mask_stride: self.width as i32,
                     };
                     blitter = &mut sb;
                 }
@@ -552,9 +552,9 @@ impl DrawTarget {
                         dest,
                         dest_stride: dest_bounds.size().width,
                         mask,
-                        mask_stride: self.width,
+                        mask_stride: self.width as i32,
                         clip,
-                        clip_stride: self.width,
+                        clip_stride: self.width as i32,
                         blend_fn
                     };
 
@@ -567,7 +567,7 @@ impl DrawTarget {
                         dest,
                         dest_stride: dest_bounds.size().width,
                         mask,
-                        mask_stride: self.width,
+                        mask_stride: self.width as i32,
                         blend_fn
                     };
                     blitter = &mut sb_blend;

--- a/src/rasterizer.rs
+++ b/src/rasterizer.rs
@@ -146,21 +146,17 @@ impl ActiveEdge {
 
 
 pub struct Rasterizer {
-    /*
-        Rasterizer(int width, int height);
-        ~Rasterizer() { delete[] edge_starts; };
-    */
     edge_starts: Vec<Option<NonNull<ActiveEdge>>>,
-    width: i32,
-    height: i32,
-    cur_y: i32,
+    width: u32,
+    height: u32,
+    cur_y: u32,
     active_edges: Option<NonNull<ActiveEdge>>,
 
     edge_arena: Arena<ActiveEdge>,
 }
 
 impl Rasterizer {
-    pub fn new(width: i32, height: i32) -> Rasterizer {
+    pub fn new(width: u32, height: u32) -> Rasterizer {
         let mut edge_starts = Vec::new();
         for _ in 0..(height * 4) {
             edge_starts.push(None);
@@ -273,7 +269,7 @@ impl Rasterizer {
         e.fullx = edge.x1 << 16;
 
         // if the edge is completely above or completely below we can drop it
-        if edge.y2 < 0 || edge.y1 > self.height {
+        if edge.y2 < 0 || edge.y1 > self.height as i32 {
             return;
         }
 
@@ -358,7 +354,7 @@ impl Rasterizer {
     fn step_edges(&mut self) {
         let mut prev_ptr = &mut self.active_edges as *mut _;
         let mut edge = self.active_edges;
-        let cury = self.cur_y; // avoid any aliasing problems
+        let cury = self.cur_y as i32; // avoid any aliasing problems
         while let Some(mut e_ptr) = edge {
             let e = unsafe { e_ptr.as_mut() };
             e.step(cury);
@@ -469,13 +465,13 @@ impl Rasterizer {
 
             if inside {
                 blitter.blit_span(
-                    self.cur_y,
+                    self.cur_y as i32,
                     (prevx + (1 << 15)) >> 16,
                     (e.fullx + (1 << 15)) >> 16,
                 );
             }
 
-            if (e.fullx >> 16) >= self.width {
+            if (e.fullx >> 16) >= self.width as i32 {
                 break;
             }
             winding += e.winding as i32;


### PR DESCRIPTION
i32 is used too heavily, so it's hard to convert everything to u32 without understanding how the library works.
And since we have to cast u32 to i32, it might be a good idea to check that width/height is <= i32::max() to prevent an overflow.

Closes #8