### PR TITLE
Implement From<SolidSource> for Source.

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -219,6 +219,12 @@ pub enum Source<'a> {
     LinearGradient(Gradient, Spread, Transform),
 }
 
+impl<'a> From<SolidSource> for Source<'a> {
+    fn from(other: SolidSource) -> Self {
+        Source::Solid(other)
+    }
+}
+
 impl<'a> Source<'a> {
     /// Creates a new linear gradient source where the start point corresponds to the gradient
     /// stop at position = 0 and the end point corresponds to the gradient stop at position = 1.


### PR DESCRIPTION
First of all, thanks for the great library :) It's exactly what I was looking for.

Then, on to business: This PR implements `From<SolidSource>` for `Source`.

This shortcut allows you to use `&SolidSource::from_unpremultiplied_argb(...).into()` instead of `&Source::Solid(SolidSource::from_unpremultiplied_argb(...))`, and saves you from having to import `Source` if you're just using solid colors.

I also wanted to implement `From<Color>` for `Source`, but that would first require jrmuizel/sw-composite#6 to be merged (and released).