### PR TITLE
Implement From<Color> for SolidSource and Source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ font-kit = { version = "0.5", optional = true }
 lyon_geom = "0.15"
 png = "0.15"
 typed-arena = "2.0"
-sw-composite = "0.7.6"
+sw-composite = "0.7.7"
 
 [features]
 default = ["text"]

--- a/src/blitter.rs
+++ b/src/blitter.rs
@@ -22,9 +22,9 @@ pub struct MaskSuperBlitter {
 }
 
 const SHIFT: i32 = crate::rasterizer::SAMPLE_SHIFT;
-const SCALE: i32 = (1 << SHIFT);
-const MASK: i32 = (SCALE - 1);
-const SUPER_MASK: i32 = ((1 << SHIFT) - 1);
+const SCALE: i32 = 1 << SHIFT;
+const MASK: i32 = SCALE - 1;
+const SUPER_MASK: i32 = (1 << SHIFT) - 1;
 
 fn coverage_to_partial_alpha(mut aa: i32) -> u8 {
     aa <<= 8 - 2 * SHIFT;

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -62,6 +62,17 @@ impl SolidSource {
     }
 }
 
+impl From<Color> for SolidSource {
+    fn from(color: Color) -> Self {
+        SolidSource::from_unpremultiplied_argb(
+            color.a(),
+            color.r(),
+            color.g(),
+            color.b(),
+        )
+    }
+}
+
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum BlendMode {
     Dst,
@@ -219,9 +230,15 @@ pub enum Source<'a> {
     LinearGradient(Gradient, Spread, Transform),
 }
 
-impl<'a> From<SolidSource> for Source<'a> {
+impl From<SolidSource> for Source<'_> {
     fn from(other: SolidSource) -> Self {
         Source::Solid(other)
+    }
+}
+
+impl From<Color> for Source<'_> {
+    fn from(color: Color) -> Self {
+        Source::Solid(SolidSource::from(color))
     }
 }
 


### PR DESCRIPTION
This PR continues on #121, now that jrmuizel/sw-composite#6 is released (for which thanks :heart:). It implements `From<Color>` for `Source` and `SolidSource`, further simplifying drawing with solid colors.

With this PR, you can write:
```rust
target.stroke(path, &Color::new(127, 255, 0, 0).into(), &style, &option);
```

It also fixes a 3 compiler warnings about unnecessary parenthesis.
