### PR TITLE
Ignore stroking when stroke-width is less then or equal zero.

### DIFF
--- a/src/stroke.rs
+++ b/src/stroke.rs
@@ -275,8 +275,13 @@ fn join_line(
 }
 
 pub fn stroke_to_path(path: &Path, style: &StrokeStyle) -> Path {
-    let mut cur_pt = None;
     let mut stroked_path = PathBuilder::new();
+
+    if style.width <= 0. {
+        return stroked_path.finish();
+    }
+
+    let mut cur_pt = None;
     let mut last_normal = Vector::zero();
     let half_width = style.width / 2.;
     let mut start_point = None;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -275,6 +275,57 @@ mod tests {
     }
 
     #[test]
+    fn zero_width_stroke() {
+        let mut dt = DrawTarget::new(3, 3);
+        let mut pb = PathBuilder::new();
+        pb.move_to(2., 2.);
+        pb.line_to(200., 300.);
+        dt.stroke(
+            &pb.finish(),
+            &WHITE_SOURCE,
+            &StrokeStyle {
+                width: 0.,
+                ..Default::default()
+            },
+            &DrawOptions::new(),
+        );
+    }
+
+    #[test]
+    fn negative_width_stroke() {
+        let mut dt = DrawTarget::new(3, 3);
+        let mut pb = PathBuilder::new();
+        pb.move_to(2., 2.);
+        pb.line_to(200., 300.);
+        dt.stroke(
+            &pb.finish(),
+            &WHITE_SOURCE,
+            &StrokeStyle {
+                width: std::f32::MIN,
+                ..Default::default()
+            },
+            &DrawOptions::new(),
+        );
+    }
+
+    #[test]
+    fn tiny_negative_width_stroke() {
+        let mut dt = DrawTarget::new(3, 3);
+        let mut pb = PathBuilder::new();
+        pb.move_to(2., 2.);
+        pb.line_to(200., 300.);
+        dt.stroke(
+            &pb.finish(),
+            &WHITE_SOURCE,
+            &StrokeStyle {
+                width: -core::f32::MIN_POSITIVE,
+                ..Default::default()
+            },
+            &DrawOptions::new(),
+        );
+    }
+
+    #[test]
     fn dashing() {
         let mut dt = DrawTarget::new(3, 3);
         let mut pb = PathBuilder::new();


### PR DESCRIPTION
Closes #137