### PR TITLE
Bump png dependency to 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ euclid = "0.20"
 font-kit = { version = "0.7", optional = true }
 lyon_geom = "0.15"
 pathfinder_geometry = { version = "0.5", optional = true }
-png = "0.15"
+png = "0.16"
 typed-arena = "2.0"
 sw-composite = "0.7.10"
 


### PR DESCRIPTION
png 0.16.5 provides much faster PNG decoding (~3x). Its performance is now in line with libpng.

Raqote itself does not benefit from that directly, but this allows switching to the newer version in downstream projects such as resvg without depending on two different versions of png crate.