### PR TITLE
Update font-kit to 0.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["graphics"]
 
 [dependencies]
 euclid = "0.20"
-font-kit = { version = "0.7", optional = true }
+font-kit = { version = "0.9", optional = true }
 lyon_geom = "0.15"
 pathfinder_geometry = { version = "0.5", optional = true }
 png = "0.16"


### PR DESCRIPTION
This will allow Servo to incorporate https://github.com/servo/font-kit/pull/156 when it's merged.