### PR TITLE
Make png optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ euclid = "0.20"
 font-kit = { version = "0.9", optional = true }
 lyon_geom = "0.15"
 pathfinder_geometry = { version = "0.5", optional = true }
-png = "0.16"
+png = { version = "0.16", optional = true }
 typed-arena = "2.0"
 sw-composite = "0.7.13"
 
 [features]
-default = ["text"]
+default = ["text", "png"]
 text = ["font-kit", "pathfinder_geometry"]

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -20,7 +20,9 @@ mod fk {
     pub use pathfinder_geometry::vector::{vec2f, vec2i};
 }
 
+#[cfg(feature = "png")]
 use std::fs::*;
+#[cfg(feature = "png")]
 use std::io::BufWriter;
 
 use crate::stroke::*;
@@ -1047,8 +1049,8 @@ impl DrawTarget {
         self.buf
     }
 
-
     /// Saves the current pixel to a png file at `path`
+    #[cfg(feature = "png")]
     pub fn write_png<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), png::EncodingError> {
         let file = File::create(path)?;
 


### PR DESCRIPTION
The `png` crate pulls in some dependencies that I don't need. It would be nice to disable it with a feature flag.