### PR TITLE
add `no_std` compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,17 @@ keywords = ["2d", "graphics"]
 categories = ["graphics"]
 
 [dependencies]
-euclid = "0.22"
+euclid = { version = "0.22", default-features = false, features = ["libm"] }
 font-kit = { version = "0.11", optional = true }
-lyon_geom = "1.0"
+lyon_geom = { version = "1.0", default-features = false }
 pathfinder_geometry = { version = "0.5", optional = true }
 png = { version = "0.17", optional = true }
-typed-arena = "2.0"
+typed-arena = { version = "2.0", default-features = false }
 sw-composite = "0.7.15"
+num-traits = { version = "0.2.17", default-features = false, features = ["libm"] }
 
 [features]
-default = ["text", "png"]
+default = ["std", "text", "png"]
+std = ["typed-arena/std", "euclid/std"]
 text = ["font-kit", "pathfinder_geometry"]
+png = ["dep:png", "std"]

--- a/src/blitter.rs
+++ b/src/blitter.rs
@@ -3,8 +3,13 @@ use sw_composite::*;
 use crate::{IntPoint, Point, Transform};
 use crate::draw_target::{ExtendMode, Source, FilterMode};
 
+use alloc::{
+    boxed::Box,
+    vec, vec::Vec
+};
+
 use euclid::vec2;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 pub trait Blitter {
     fn blit_span(&mut self, y: i32, x1: i32, x2: i32, mask: &[u8]);

--- a/src/dash.rs
+++ b/src/dash.rs
@@ -2,6 +2,8 @@ use crate::path_builder::*;
 
 use crate::Point;
 
+use alloc::vec::Vec;
+
 use lyon_geom::LineSegment;
 
 #[derive(Clone, Copy)]

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -10,6 +10,11 @@ use crate::path_builder::*;
 pub use crate::path_builder::Winding;
 use lyon_geom::CubicBezierSegment;
 
+use alloc::{vec, vec::Vec};
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[cfg(feature = "text")]
 mod fk {
     pub use font_kit::canvas::{Canvas, Format, RasterizationOptions};
@@ -1072,7 +1077,7 @@ impl<Backing : AsRef<[u32]> + AsMut<[u32]>> DrawTarget<Backing> {
         let len = buf.len();
         // we want to return an [u8] slice instead of a [u32] slice. This is a safe thing to
         // do because requirements of a [u32] slice are stricter.
-        unsafe { std::slice::from_raw_parts(p as *const u8, len * std::mem::size_of::<u32>()) }
+        unsafe { core::slice::from_raw_parts(p as *const u8, len * core::mem::size_of::<u32>()) }
     }
 
     /// Returns a mut reference to the underlying pixel data as individual bytes with the order BGRA
@@ -1083,7 +1088,7 @@ impl<Backing : AsRef<[u32]> + AsMut<[u32]>> DrawTarget<Backing> {
         let len = buf.len();
         // we want to return an [u8] slice instead of a [u32] slice. This is a safe thing to
         // do because requirements of a [u32] slice are stricter.
-        unsafe { std::slice::from_raw_parts_mut(p as *mut u8, len * std::mem::size_of::<u32>()) }
+        unsafe { core::slice::from_raw_parts_mut(p as *mut u8, len * core::mem::size_of::<u32>()) }
     }
 
     /// Take ownership of the buffer backing the DrawTarget
@@ -1094,7 +1099,7 @@ impl<Backing : AsRef<[u32]> + AsMut<[u32]>> DrawTarget<Backing> {
     /// Saves the current pixel to a png file at `path`
     #[cfg(feature = "png")]
     pub fn write_png<P: AsRef<std::path::Path>>(&self, path: P) -> Result<(), png::EncodingError> {
-        let file = File::create(path)?;
+        let file = std::fs::File::create(path)?;
 
         let w = &mut BufWriter::new(file);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,13 @@ Produces:
 
 #![warn(missing_copy_implementations)]
 
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
+
 mod blitter;
 mod dash;
 mod draw_target;

--- a/src/path_builder.rs
+++ b/src/path_builder.rs
@@ -5,6 +5,8 @@ use lyon_geom::QuadraticBezierSegment;
 
 use crate::{Point, Transform, Vector};
 
+use alloc::vec::Vec;
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Winding {
     EvenOdd,

--- a/src/rasterizer.rs
+++ b/src/rasterizer.rs
@@ -17,7 +17,9 @@ use crate::blitter::RasterBlitter;
 use crate::path_builder::Winding;
 use crate::geom::intrect;
 
-use std::ptr::NonNull;
+use core::ptr::NonNull;
+
+use alloc::vec::Vec;
 
 // One reason to have separate Edge/ActiveEdge is reduce the
 // memory usage of inactive edges. On the other hand
@@ -313,7 +315,7 @@ impl Rasterizer {
         // how do we deal with edges to the right and left of the canvas?
         let e = self.edge_arena.alloc(ActiveEdge::new());
         if end.y < start.y {
-            std::mem::swap(&mut start, &mut end);
+            core::mem::swap(&mut start, &mut end);
             e.winding = -1;
         } else {
             e.winding = 1;

--- a/src/stroke.rs
+++ b/src/stroke.rs
@@ -4,6 +4,11 @@
 use crate::path_builder::{Path, PathBuilder, PathOp};
 use crate::{Point, Vector};
 
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct StrokeStyle {
     pub width: f32,
@@ -242,7 +247,7 @@ fn join_line(
     if is_interior_angle(s1_normal, s2_normal) {
         s2_normal = flip(s2_normal);
         s1_normal = flip(s1_normal);
-        std::mem::swap(&mut s1_normal, &mut s2_normal);
+        core::mem::swap(&mut s1_normal, &mut s2_normal);
     }
 
     // XXX: joining uses `pt` which can cause seams because it lies halfway on a line and the

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
-
+    use alloc::{vec, vec::Vec};
+    
     use crate::geom::intrect;
     use crate::*;
     const WHITE_SOURCE: Source = Source::Solid(SolidSource {
@@ -301,7 +302,7 @@ mod tests {
             &pb.finish(),
             &WHITE_SOURCE,
             &StrokeStyle {
-                width: std::f32::MIN,
+                width: core::f32::MIN,
                 ..Default::default()
             },
             &DrawOptions::new(),
@@ -757,7 +758,7 @@ mod tests {
     #[test]
     fn arc_contains() {
         let mut pb = PathBuilder::new();
-        pb.arc(50., 25., 10., 0., std::f32::consts::PI);
+        pb.arc(50., 25., 10., 0., core::f32::consts::PI);
         let path = pb.finish();
         assert!(!path.contains_point(0.1, 50., 10.));
         assert!(!path.contains_point(0.1, 50., 20.));


### PR DESCRIPTION
As mentioned in [this PR](https://github.com/jrmuizel/sw-composite/pull/14), I have an interest in making this crate `no_std` compatible.

The changes in this crate are dependent on the `sw-composite` PR and I've made similar changes here, with the only difference being conditionally activating the `std` feature of some dependencies in line with the new `std` default feature, and requiring the `std` feature if using the `png` feature.

Let me know if anything should be fixed, thanks!