### PR TITLE
Update pathfinder, fix CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ png = { version = "0.17", optional = true }
 typed-arena = "2.0"
 sw-composite = "0.7.15"
 
+[patch.crates-io]
+# patching to use latest pathfinder until pathfinder releases to crates-io
+pathfinder_simd = { git = "https://github.com/servo/pathfinder" }
+pathfinder_geometry = { git = "https://github.com/servo/pathfinder" }
+
 [features]
 default = ["text", "png"]
 text = ["font-kit", "pathfinder_geometry"]


### PR DESCRIPTION
Blocked on servo/pathfinder releasing a new version to crates.io

The main change we care about, that fixes the CI pipeline for raqote, is https://github.com/servo/pathfinder/pull/548.