### PR TITLE
Implement ellipses

### DIFF
--- a/src/path_builder.rs
+++ b/src/path_builder.rs
@@ -279,10 +279,19 @@ impl PathBuilder {
     /// For a positive `sweep_angle` the sweep is done clockwise, for a negative
     /// `sweep_angle` the sweep is done counterclockwise.
     pub fn arc(&mut self, x: f32, y: f32, r: f32, start_angle: f32, sweep_angle: f32) {
+        self.ellipse(x, y, r, r, start_angle, sweep_angle);
+    }
+
+    /// Adds an arc approximated by quadratic beziers with center `x`, `y`
+    /// and radius components `x_radius`, `y_radius` starting at `start_angle`
+    /// and sweeping by `sweep_angle`. For a positive `sweep_angle` the sweep
+    /// is done clockwise, for a negative `sweep_angle` the sweep is done
+    /// counterclockwise.
+    pub fn ellipse(&mut self, x: f32, y: f32, radius_x: f32, radius_y: f32, start_angle: f32, sweep_angle: f32) {
         //XXX: handle the current point being the wrong spot
         let a: Arc<f32> = Arc {
             center: Point::new(x, y),
-            radii: Vector::new(r, r),
+            radii: Vector::new(radius_x, radius_y),
             start_angle: Angle::radians(start_angle),
             sweep_angle: Angle::radians(sweep_angle),
             x_rotation: Angle::zero(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -770,6 +770,24 @@ mod tests {
     }
 
     #[test]
+    fn ellipse_contains() {
+        let mut pb = PathBuilder::new();
+        pb.ellipse(50., 25., 10., 20., 0., std::f32::consts::PI);
+        let path = pb.finish();
+        assert!(!path.contains_point(0.1, 50., 10.));
+        assert!(!path.contains_point(0.1, 50., 20.));
+        assert!(path.contains_point(0.1, 50., 30.));
+        assert!(path.contains_point(0.1, 50., 40.));
+        assert!(!path.contains_point(0.1, 30., 20.));
+        assert!(!path.contains_point(0.1, 70., 20.));
+        assert!(!path.contains_point(0.1, 30., 30.));
+        assert!(!path.contains_point(0.1, 70., 30.));
+        assert!(!path.contains_point(0.1, 30., 40.));
+        assert!(!path.contains_point(0.1, 50., 50.));
+        assert!(!path.contains_point(0.1, 70., 40.));
+    }
+
+    #[test]
     fn new_linear_gradient_zerosize() {
         let source = Source::new_linear_gradient(
             Gradient { stops: Vec::new() },


### PR DESCRIPTION
I needed a way to render ellipses, and found that it was a simple API limitation preventing this (the PR itself does not result in any API changes, though).

I'm still unsure about the naming, since it's kind of made unclear that `arc` and `ellipse` are the same thing. However, I think the central idea and implementation for this change is pretty acceptable.

Closes #120 (probably).