### PR TITLE
Fix vector capacity overflow panic

### DIFF
--- a/src/blitter.rs
+++ b/src/blitter.rs
@@ -38,7 +38,7 @@ impl MaskSuperBlitter {
             width,
             // we can end up writing one byte past the end of the buffer so allocate that
             // padding to avoid needing to do an extra check
-            buf: vec![0; (width * height) as usize + 1],
+            buf: vec![0; (width as i64 * height as i64) as usize + 1],
         }
     }
 }
@@ -99,7 +99,7 @@ impl MaskBlitter {
             width,
             // we can end up writing one byte past the end of the buffer so allocate that
             // padding to avoid needing to do an extra check
-            buf: vec![0; (width * height) as usize + 1],
+            buf: vec![0; (width as i64 * height as i64) as usize + 1],
         }
     }
 }

--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -370,7 +370,7 @@ impl DrawTarget {
             current_point: None,
             first_point: None,
             rasterizer: Rasterizer::new(width, height),
-            buf: vec![0; (width * height) as usize],
+            buf: vec![0; (width as i64 * height as i64) as usize],
             clip_stack: Vec::new(),
             layer_stack: Vec::new(),
             transform: Transform::identity(),
@@ -379,7 +379,7 @@ impl DrawTarget {
 
     /// Use a previously used vector for the bitmap and extend it to the given size(if needed)
     pub fn from_vec(width: i32, height: i32, mut vec: Vec<u32>) -> DrawTarget{
-        vec.resize((width*height) as usize, 0);
+        vec.resize((width as i64 * height as i64) as usize, 0);
         DrawTarget {
             width,
             height,
@@ -404,7 +404,7 @@ impl<Backing : AsRef<[u32]> + AsMut<[u32]>> DrawTarget<Backing> {
     ///
     /// The backing store must be the correct size (width*height elements).
     pub fn from_backing(width: i32, height: i32, buf : Backing) -> Self {
-        assert_eq!((width*height) as usize, buf.as_ref().len());
+        assert_eq!((width as i64 * height as i64) as usize, buf.as_ref().len());
         DrawTarget {
             width,
             height,


### PR DESCRIPTION
For some cases draw target could be created with
large width and/or height values and it causes panic at runtime:
- debug build: panic_const_mul_overflow ("attempt to multiply with overflow") for "(width * height) as usize" expression

- release build: panic ("capacity overflow") on memory allocation https://doc.rust-lang.org/src/alloc/raw_vec.rs.html#459

For example "width * height" - "2147483647 * 50" (i32::MAX * 50)
and (-50, true) = 2147483647i32.overflowing_mul(50), there are
-50 as usize -> 18446744073709551566 (0xFFFFFFFFFFFFFFCE).
And on vector allocation with u32::LAYOUT with such capacity we have mul overflow (panic "capacity overflow").

To prevent it lets use lossless conversion from i32 to i64 and mul output i64 (without overflow) to usize.

Related to https://github.com/jrmuizel/raqote/issues/9