### PR TITLE
Fix intersection bug in DrawTarget.copy_surface

### DIFF
--- a/src/draw_target.rs
+++ b/src/draw_target.rs
@@ -1000,21 +1000,23 @@ impl<Backing : AsRef<[u32]> + AsMut<[u32]>> DrawTarget<Backing> {
 
     /// Draws `src_rect` of `src` at `dst`. The current transform and clip are ignored
     pub fn composite_surface<F: Fn(&[u32], &mut [u32]), SrcBacking: AsRef<[u32]>>(&mut self, src: &DrawTarget<SrcBacking>, src_rect: IntRect, dst: IntPoint, f: F) {
-        let dst_rect = intrect(0, 0, self.width, self.height);
+        let dst_bounds = intrect(0, 0, self.width, self.height);
+
+        // retain coordinate mapping from source to destination coordinates
+        let src_to_dst_vec = dst - src_rect.min;
 
         // intersect the src_rect with the source size so that we don't go out of bounds
         let src_rect = src_rect.intersection_unchecked(&intrect(0, 0, src.width, src.height));
 
-        let src_rect = dst_rect
-            .intersection_unchecked(&src_rect.translate(dst.to_vector())).translate(-dst.to_vector());
-
-        // clamp requires Float so open code it
-        let dst = IntPoint::new(dst.x.max(dst_rect.min.x).min(dst_rect.max.x),
-                                dst.y.max(dst_rect.min.y).min(dst_rect.max.y));
+        // intersect the remaining src_rect against the dst_bounds by first translating into dst space
+        let src_rect = dst_bounds
+            .intersection_unchecked(&src_rect.translate(src_to_dst_vec)).translate(-src_to_dst_vec);
 
         if src_rect.is_empty() {
             return;
         }
+
+        let dst = src_rect.min + src_to_dst_vec;
 
         for y in src_rect.min.y..src_rect.max.y {
             let dst_row_start = (dst.x + (dst.y + y - src_rect.min.y) * self.width) as usize;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -595,6 +595,16 @@ mod tests {
         assert_eq!(dest.get_data(), &vec![blue, green, red, 0][..]);
         dest.copy_surface(&src, intrect(0, 0, 2, 2), IntPoint::new(1, 1));
         assert_eq!(dest.get_data(), &vec![blue, green, red, white][..]);
+
+        let mut dest = DrawTarget::new(2, 2);
+        dest.copy_surface(&src, intrect(-1, -1, 1, 1), IntPoint::new(0, 0));
+        assert_eq!(dest.get_data(), &vec![0, 0, 0, white][..]);
+        dest.copy_surface(&src, intrect(1, -1, 3, 1), IntPoint::new(0, 0));
+        assert_eq!(dest.get_data(), &vec![0, 0, red, white][..]);
+        dest.copy_surface(&src, intrect(-1, 1, 1, 3), IntPoint::new(0, 0));
+        assert_eq!(dest.get_data(), &vec![0, green, red, white][..]);
+        dest.copy_surface(&src, intrect(1, 1, 3, 3), IntPoint::new(0, 0));
+        assert_eq!(dest.get_data(), &vec![blue, green, red, white][..]);
     }
 
     #[test]


### PR DESCRIPTION
 If the src_rect passed to copy_surface is outside the src bounds then the copy_surface code doesn't offset correctly into 'dst'.

Rough illustration:

```rust
dest.copy_surface(&src, intrect(-1, -1, 1, 1), IntPoint::new(0, 0));
```

```
src_rect         dst expected
+---+            +---+
| +-|--+         |   |
| |x|  |         |  x|
+---+  |         +---+
  |    |
  +----+          dst actual
    src           +---+
                  |x  |
                  |   |
                  +---+
```